### PR TITLE
feat: update theme to purple and new logo

### DIFF
--- a/packages/twenty-ui/src/theme/constants/AccentDark.ts
+++ b/packages/twenty-ui/src/theme/constants/AccentDark.ts
@@ -1,10 +1,10 @@
 import { COLOR } from './Colors';
 
 export const ACCENT_DARK = {
-  primary: COLOR.blueAccent75,
-  secondary: COLOR.blueAccent80,
-  tertiary: COLOR.blueAccent85,
-  quaternary: COLOR.blueAccent90,
-  accent3570: COLOR.blueAccent70,
-  accent4060: COLOR.blueAccent60,
+  primary: COLOR.purple60,
+  secondary: COLOR.purple70,
+  tertiary: COLOR.purple80,
+  quaternary: COLOR.purple80,
+  accent3570: COLOR.purple50,
+  accent4060: COLOR.purple40,
 };

--- a/packages/twenty-ui/src/theme/constants/AccentLight.ts
+++ b/packages/twenty-ui/src/theme/constants/AccentLight.ts
@@ -1,10 +1,10 @@
 import { COLOR } from './Colors';
 
 export const ACCENT_LIGHT = {
-  primary: COLOR.blueAccent25,
-  secondary: COLOR.blueAccent20,
-  tertiary: COLOR.blueAccent15,
-  quaternary: COLOR.blueAccent10,
-  accent3570: COLOR.blueAccent35,
-  accent4060: COLOR.blueAccent40,
+  primary: COLOR.purple40,
+  secondary: COLOR.purple30,
+  tertiary: COLOR.purple20,
+  quaternary: COLOR.purple10,
+  accent3570: COLOR.purple50,
+  accent4060: COLOR.purple60,
 };

--- a/packages/twenty-website/public/images/core/logo-purple.svg
+++ b/packages/twenty-website/public/images/core/logo-purple.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40" fill="none">
+  <rect width="40" height="40" rx="8" fill="#915ffd"/>
+</svg>

--- a/packages/twenty-website/src/app/_components/ui/layout/Logo.tsx
+++ b/packages/twenty-website/src/app/_components/ui/layout/Logo.tsx
@@ -8,7 +8,7 @@ const Link = styled.a`
   border-radius: 8px;
   height: 40px;
   width: 40px;
-  background-image: url('/images/core/logo.svg');
+  background-image: url('/images/core/logo-purple.svg');
   opacity: 1;
 `;
 


### PR DESCRIPTION
## Summary
- switch accent colors to a purple palette
- replace website logo with purple variant

## Testing
- `yarn nx test twenty-ui`
- `yarn nx test twenty-website` *(fails: Cannot find configuration for task twenty-website:test)*
- `yarn nx lint twenty-ui`
- `yarn nx lint twenty-website` *(fails: Running target lint for project twenty-website failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b31cd515648322b32380b87492c423